### PR TITLE
Change rpc binding to make cass container accessible via localhost to others in Kubernetes pod

### DIFF
--- a/cassandra-run
+++ b/cassandra-run
@@ -19,7 +19,7 @@ if [ ! -f /root/.cassconfig ]; then
     # Add broadcast IPs
     echo "listen_address: $ADDR" >> $CONF_FILE
     echo "broadcast_rpc_address: $ADDR" >> $CONF_FILE
-    echo "rpc_address: $ADDR" >> $CONF_FILE
+    echo "rpc_address: 0.0.0.0" >> $CONF_FILE
     # Add seed info
     echo "seed_provider:" >> $CONF_FILE
     echo "  - class_name: org.apache.cassandra.locator.SimpleSeedProvider" >> $CONF_FILE


### PR DESCRIPTION
In Kubernetes when deploying docker-cassandra with another container in the same pod cassandra is not available on localhost: 9042.  Changing rpc_address to 0.0.0.0 seemed to fix it.
