### PR TITLE
fix agent config path

### DIFF
--- a/agent-run
+++ b/agent-run
@@ -7,7 +7,7 @@ else
 	if [ ! -f /root/.agentconfig ]; then
 		echo "Filling in the blanks inside address.yaml"
 		cd /opt/agent/conf
-		echo "stomp_interface: $OPS_IP" >> ./conf/address.yaml
+		echo "stomp_interface: $OPS_IP" >> ./address.yaml
 		touch /root/.agentconfig
 	fi
 


### PR DESCRIPTION
Due to an issue in the agent properties `address.yaml` path, the agent is not able to reach the configured OpsCenter.
